### PR TITLE
renaming: MatterModels -> ElectronicSturctureModels

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -25,11 +25,11 @@ CodeOfConductContact: u.hernandez@hzdr.de
 ConfigIndentation: 2
 JuliaIndentation: 4
 JuliaMinCIVersion: lts
-JuliaMinVersion: '1.10'
+JuliaMinVersion: "1.10"
 License: MIT
 LicenseCopyrightHolders: Uwe Hernandez Acosta
 MarkdownIndentation: 2
-PackageName: MatterModels
+PackageName: ElectronicStructureModels
 PackageOwner: JuliaXRTS
 PackageUUID: 89b7eb7d-0b8d-5078-86d5-4a0f481f2984
 RunJuliaNightlyOnCI: false

--- a/.github/ISSUE_TEMPLATE/10-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/10-bug-report.yml
@@ -10,9 +10,9 @@ body:
 
         Please, before submitting, make sure that:
 
-        - There is not an [existing issue](https://github.com/JuliaXRTS/MatterModels.jl/issues) with the same question
-        - You have read the [contributing guide](https://JuliaXRTS.github.io/MatterModels.jl/dev/90-contributing/)
-        - You are following the [code of conduct](https://github.com/JuliaXRTS/MatterModels.jl/blob/main/CODE_OF_CONDUCT.md)
+        - There is not an [existing issue](https://github.com/JuliaXRTS/ElectronicStructureModels.jl/issues) with the same question
+        - You have read the [contributing guide](https://JuliaXRTS.github.io/ElectronicStructureModels.jl/dev/90-contributing/)
+        - You are following the [code of conduct](https://github.com/JuliaXRTS/ElectronicStructureModels.jl/blob/main/CODE_OF_CONDUCT.md)
         The form below should help you in filling out this issue.
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/20-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/20-feature-request.yml
@@ -8,9 +8,9 @@ body:
 
         Please, before submitting, make sure that:
 
-        - There is not an [existing issue](https://github.com/JuliaXRTS/MatterModels.jl/issues) with the same question
-        - You have read the [contributing guide](https://JuliaXRTS.github.io/MatterModels.jl/dev/90-contributing/)
-        - You are following the [code of conduct](https://github.com/JuliaXRTS/MatterModels.jl/blob/main/CODE_OF_CONDUCT.md)
+        - There is not an [existing issue](https://github.com/JuliaXRTS/ElectronicStructureModels.jl/issues) with the same question
+        - You have read the [contributing guide](https://JuliaXRTS.github.io/ElectronicStructureModels.jl/dev/90-contributing/)
+        - You are following the [code of conduct](https://github.com/JuliaXRTS/ElectronicStructureModels.jl/blob/main/CODE_OF_CONDUCT.md)
         The form below should help you in filling out this issue.
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/30-usage.yml
+++ b/.github/ISSUE_TEMPLATE/30-usage.yml
@@ -9,10 +9,10 @@ body:
 
         Please, before submitting, make sure that:
 
-        - You have checked the [documentation](https://JuliaXRTS.github.io/MatterModels.jl) and haven't found enough information
-        - There is not an [existing issue](https://github.com/JuliaXRTS/MatterModels.jl/issues) with the same question
-        - You have read the [contributing guide](https://JuliaXRTS.github.io/MatterModels.jl/dev/90-contributing/)
-        - You are following the [code of conduct](https://github.com/JuliaXRTS/MatterModels.jl/blob/main/CODE_OF_CONDUCT.md)
+        - You have checked the [documentation](https://JuliaXRTS.github.io/ElectronicStructureModels.jl) and haven't found enough information
+        - There is not an [existing issue](https://github.com/JuliaXRTS/ElectronicStructureModels.jl/issues) with the same question
+        - You have read the [contributing guide](https://JuliaXRTS.github.io/ElectronicStructureModels.jl/dev/90-contributing/)
+        - You are following the [code of conduct](https://github.com/JuliaXRTS/ElectronicStructureModels.jl/blob/main/CODE_OF_CONDUCT.md)
         The form below should help you in filling out this issue.
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/99-general.yml
+++ b/.github/ISSUE_TEMPLATE/99-general.yml
@@ -8,9 +8,9 @@ body:
 
         Please, before submitting, make sure that:
 
-        - There is not an [existing issue](https://github.com/JuliaXRTS/MatterModels.jl/issues) with the same question
-        - You have read the [contributing guide](https://JuliaXRTS.github.io/MatterModels.jl/dev/90-contributing/)
-        - You are following the [code of conduct](https://github.com/JuliaXRTS/MatterModels.jl/blob/main/CODE_OF_CONDUCT.md)
+        - There is not an [existing issue](https://github.com/JuliaXRTS/ElectronicStructureModels.jl/issues) with the same question
+        - You have read the [contributing guide](https://JuliaXRTS.github.io/ElectronicStructureModels.jl/dev/90-contributing/)
+        - You are following the [code of conduct](https://github.com/JuliaXRTS/ElectronicStructureModels.jl/blob/main/CODE_OF_CONDUCT.md)
         The form below should help you in filling out this issue.
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Discussions
-    url: https://github.com/JuliaXRTS/MatterModels.jl/discussions
+    url: https://github.com/JuliaXRTS/ElectronicStructureModels.jl/discussions
     about: Create and follow discussions here

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!--
-Thanks for making a pull request to MatterModels.jl.
+Thanks for making a pull request to ElectronicStructureModels.jl.
 We have added this PR template to help you help us.
 Make sure to read the contributing guidelines and abide by the code of conduct.
 See the comments below, fill the required fields, and check the items.
@@ -10,6 +10,7 @@ See the comments below, fill the required fields, and check the items.
 <!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->
 
 <!-- Option 1, this closes an existing issue. Fill the number below-->
+
 Closes #
 
 <!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
@@ -21,7 +22,8 @@ There is no related issue.
 
 <!-- mark true if NA -->
 <!-- leave PR as draft until all is checked -->
-- [ ] I am following the [contributing guidelines](https://github.com/JuliaXRTS/MatterModels.jl/blob/main/docs/src/90-contributing.md)
+
+- [ ] I am following the [contributing guidelines](https://github.com/JuliaXRTS/ElectronicStructureModels.jl/blob/main/docs/src/90-contributing.md)
 - [ ] Tests are passing
 - [ ] Lint workflow is passing
 - [ ] Docs were updated and workflow is passing

--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -45,9 +45,9 @@ jobs:
         run: |
           julia --project=docs -e '
             using Documenter: DocMeta, doctest
-            using MatterModels
-            DocMeta.setdocmeta!(MatterModels, :DocTestSetup, :(using MatterModels); recursive=true)
-            doctest(MatterModels)'
+            using ElectronicStructureModels
+            DocMeta.setdocmeta!(ElectronicStructureModels, :DocTestSetup, :(using ElectronicStructureModels); recursive=true)
+            doctest(ElectronicStructureModels)'
       - name: Generate and deploy documentation
         run: julia --project=docs docs/make.jl
         env:

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -3,10 +3,8 @@ exclude = [
   "@cite",
   "^https://github.com/.*/releases/tag/v.*$",
   "^https://doi.org/FIXME$",
-  "^https://JuliaXRTS.github.io/MatterModels.jl/stable$",
-  "zenodo.org/badge/DOI/FIXME$"
+  "^https://JuliaXRTS.github.io/ElectronicStructureModels.jl/stable$",
+  "zenodo.org/badge/DOI/FIXME$",
 ]
 
-exclude_path = [
-  "docs/build"
-]
+exclude_path = ["docs/build"]

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,6 @@
 # Go to https://citation-file-format.github.io/cff-initializer-javascript/#/ to finish this
 cff-version: 1.2.0
-title: MatterModels.jl
+title: ElectronicStructureModels.jl
 message: >-
   If you use this software, please cite it using the
   metadata from this file.

--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,4 @@
-name = "MatterModels"
+name = "ElectronicStructureModels"
 uuid = "89b7eb7d-0b8d-5078-86d5-4a0f481f2984"
 version = "0.1.0"
 authors = ["Uwe Hernandez Acosta <u.hernandez@hzdr.de>"]

--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
-# MatterModels
+# ElectronicStructureModels
 
-[![Stable Documentation](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaXRTS.github.io/MatterModels.jl/stable)
-[![Development documentation](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaXRTS.github.io/MatterModels.jl/dev)
-[![Test workflow status](https://github.com/JuliaXRTS/MatterModels.jl/actions/workflows/Test.yml/badge.svg?branch=main)](https://github.com/JuliaXRTS/MatterModels.jl/actions/workflows/Test.yml?query=branch%3Amain)
-[![Coverage](https://codecov.io/gh/JuliaXRTS/MatterModels.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/JuliaXRTS/MatterModels.jl)
-[![Lint workflow Status](https://github.com/JuliaXRTS/MatterModels.jl/actions/workflows/Lint.yml/badge.svg?branch=main)](https://github.com/JuliaXRTS/MatterModels.jl/actions/workflows/Lint.yml?query=branch%3Amain)
-[![Docs workflow Status](https://github.com/JuliaXRTS/MatterModels.jl/actions/workflows/Docs.yml/badge.svg?branch=main)](https://github.com/JuliaXRTS/MatterModels.jl/actions/workflows/Docs.yml?query=branch%3Amain)
+[![Stable Documentation](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaXRTS.github.io/ElectronicStructureModels.jl/stable)
+[![Development documentation](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaXRTS.github.io/ElectronicStructureModels.jl/dev)
+[![Test workflow status](https://github.com/JuliaXRTS/ElectronicStructureModels.jl/actions/workflows/Test.yml/badge.svg?branch=main)](https://github.com/JuliaXRTS/ElectronicStructureModels.jl/actions/workflows/Test.yml?query=branch%3Amain)
+[![Coverage](https://codecov.io/gh/JuliaXRTS/ElectronicStructureModels.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/JuliaXRTS/ElectronicStructureModels.jl)
+[![Lint workflow Status](https://github.com/JuliaXRTS/ElectronicStructureModels.jl/actions/workflows/Lint.yml/badge.svg?branch=main)](https://github.com/JuliaXRTS/ElectronicStructureModels.jl/actions/workflows/Lint.yml?query=branch%3Amain)
+[![Docs workflow Status](https://github.com/JuliaXRTS/ElectronicStructureModels.jl/actions/workflows/Docs.yml/badge.svg?branch=main)](https://github.com/JuliaXRTS/ElectronicStructureModels.jl/actions/workflows/Docs.yml?query=branch%3Amain)
 [![DOI](https://zenodo.org/badge/DOI/FIXME)](https://doi.org/FIXME)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
-[![All Contributors](https://img.shields.io/github/all-contributors/JuliaXRTS/MatterModels.jl?labelColor=5e1ec7&color=c0ffee&style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/github/all-contributors/JuliaXRTS/ElectronicStructureModels.jl?labelColor=5e1ec7&color=c0ffee&style=flat-square)](#contributors)
 [![BestieTemplate](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/JuliaBesties/BestieTemplate.jl/main/docs/src/assets/badge.json)](https://github.com/JuliaBesties/BestieTemplate.jl)
 
 ## How to Cite
 
-If you use MatterModels.jl in your work, please cite using the reference given in [CITATION.cff](https://github.com/JuliaXRTS/MatterModels.jl/blob/main/CITATION.cff).
+If you use ElectronicStructureModels.jl in your work, please cite using the reference given in [CITATION.cff](https://github.com/JuliaXRTS/ElectronicStructureModels.jl/blob/main/CITATION.cff).
 
 ## Contributing
 
-If you want to make contributions of any kind, please first that a look into our [contributing guide directly on GitHub](docs/src/90-contributing.md) or the [contributing page on the website](https://JuliaXRTS.github.io/MatterModels.jl/dev/90-contributing/)
+If you want to make contributions of any kind, please first that a look into our [contributing guide directly on GitHub](docs/src/90-contributing.md) or the [contributing page on the website](https://JuliaXRTS.github.io/ElectronicStructureModels.jl/dev/90-contributing/)
 
 ---
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -5,7 +5,7 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 LiveServer = "16fef848-5104-11e9-1b77-fb7a48bbb589"
-MatterModels = "89b7eb7d-0b8d-5078-86d5-4a0f481f2984"
+ElectronicStructureModels = "89b7eb7d-0b8d-5078-86d5-4a0f481f2984"
 
 [compat]
 Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,7 +1,7 @@
-using MatterModels
+using ElectronicStructureModels
 using Documenter
 
-DocMeta.setdocmeta!(MatterModels, :DocTestSetup, :(using MatterModels); recursive = true)
+DocMeta.setdocmeta!(ElectronicStructureModels, :DocTestSetup, :(using ElectronicStructureModels); recursive = true)
 
 const page_rename = Dict("developer.md" => "Developer docs") # Without the numbers
 const numbered_pages = [
@@ -10,12 +10,12 @@ const numbered_pages = [
 ]
 
 makedocs(;
-    modules = [MatterModels],
+    modules = [ElectronicStructureModels],
     authors = "Uwe Hernandez Acosta <u.hernandez@hzdr.de>",
-    repo = "https://github.com/JuliaXRTS/MatterModels.jl/blob/{commit}{path}#{line}",
-    sitename = "MatterModels.jl",
-    format = Documenter.HTML(; canonical = "https://JuliaXRTS.github.io/MatterModels.jl"),
+    repo = "https://github.com/JuliaXRTS/ElectronicStructureModels.jl/blob/{commit}{path}#{line}",
+    sitename = "ElectronicStructureModels.jl",
+    format = Documenter.HTML(; canonical = "https://JuliaXRTS.github.io/ElectronicStructureModels.jl"),
     pages = ["index.md"; numbered_pages],
 )
 
-deploydocs(; repo = "github.com/JuliaXRTS/MatterModels.jl")
+deploydocs(; repo = "github.com/JuliaXRTS/ElectronicStructureModels.jl", push_preview = true)

--- a/docs/src/90-contributing.md
+++ b/docs/src/90-contributing.md
@@ -8,7 +8,7 @@ Be polite and respectful, and follow the code of conduct.
 
 ## Bug reports and discussions
 
-If you think you found a bug, feel free to open an [issue](https://github.com/JuliaXRTS/MatterModels.jl/issues).
+If you think you found a bug, feel free to open an [issue](https://github.com/JuliaXRTS/ElectronicStructureModels.jl/issues).
 Focused suggestions and requests can also be opened as issues.
 Before opening a pull request, start an issue or a discussion on the topic, please.
 
@@ -19,7 +19,7 @@ If the solution to the issue is clear, you can immediately create a pull request
 Otherwise, say what your proposed solution is and wait for a discussion around it.
 
 !!! tip
-    Feel free to ping us after a few days if there are no responses.
+Feel free to ping us after a few days if there are no responses.
 
 If your solution involves code (or something that requires running the package locally), check the [developer documentation](91-developer.md).
 Otherwise, you can use the GitHub interface directly to create your pull request.

--- a/docs/src/91-developer.md
+++ b/docs/src/91-developer.md
@@ -1,14 +1,14 @@
 # [Developer documentation](@id dev_docs)
 
 !!! note "Contributing guidelines"
-    If you haven't, please read the [Contributing guidelines](90-contributing.md) first.
+If you haven't, please read the [Contributing guidelines](90-contributing.md) first.
 
 If you want to make contributions to this package that involves code, then this guide is for you.
 
 ## First time clone
 
 !!! tip "If you have writing rights"
-    If you have writing rights, you don't have to fork. Instead, simply clone and skip ahead. Whenever **upstream** is mentioned, use **origin** instead.
+If you have writing rights, you don't have to fork. Instead, simply clone and skip ahead. Whenever **upstream** is mentioned, use **origin** instead.
 
 If this is the first time you work with this repository, follow the instructions below to clone the repository.
 
@@ -17,7 +17,7 @@ If this is the first time you work with this repository, follow the instructions
 3. Add this repo as a remote:
 
    ```bash
-   git remote add upstream https://github.com/JuliaXRTS/MatterModels.jl
+   git remote add upstream https://github.com/JuliaXRTS/ElectronicStructureModels.jl
    ```
 
 This will ensure that you have two remotes in your git: `origin` and `upstream`.
@@ -103,7 +103,7 @@ We try to keep a linear history in this repo, so it is important to keep your br
 
 ### Commit message
 
-- Use imperative or present tense, for instance: *Add feature* or *Fix bug*.
+- Use imperative or present tense, for instance: _Add feature_ or _Fix bug_.
 - Have informative titles.
 - When necessary, add a body with details.
 - If there are breaking changes, add the information to the commit message.
@@ -111,7 +111,7 @@ We try to keep a linear history in this repo, so it is important to keep your br
 ### Before creating a pull request
 
 !!! tip "Atomic git commits"
-    Try to create "atomic git commits" (recommended reading: [The Utopic Git History](https://blog.esciencecenter.nl/the-utopic-git-history-d44b81c09593)).
+Try to create "atomic git commits" (recommended reading: [The Utopic Git History](https://blog.esciencecenter.nl/the-utopic-git-history-d44b81c09593)).
 
 - Make sure the tests pass.
 - Make sure the pre-commit tests pass.
@@ -149,7 +149,7 @@ To create a new release, you can follow these simple steps:
   - Add a new link in the bottom for version "x.y.z"
   - Change the "[unreleased]" link to use the latest version - end of line, `vx.y.z ... HEAD`.
 - Create a commit "Release vx.y.z", push, create a PR, wait for it to pass, merge the PR.
-- Go back to main screen and click on the latest commit (link: <https://github.com/JuliaXRTS/MatterModels.jl/commit/main>)
+- Go back to main screen and click on the latest commit (link: <https://github.com/JuliaXRTS/ElectronicStructureModels.jl/commit/main>)
 - At the bottom, write `@JuliaRegistrator register`
 
 After that, you only need to wait and verify:
@@ -157,7 +157,7 @@ After that, you only need to wait and verify:
 - Wait for the bot to comment (should take < 1m) with a link to a PR to the registry
 - Follow the link and wait for a comment on the auto-merge
 - The comment should said all is well and auto-merge should occur shortly
-- After the merge happens, TagBot will trigger and create a new GitHub tag. Check on <https://github.com/JuliaXRTS/MatterModels.jl/releases>
+- After the merge happens, TagBot will trigger and create a new GitHub tag. Check on <https://github.com/JuliaXRTS/ElectronicStructureModels.jl/releases>
 - After the release is create, a "docs" GitHub action will start for the tag.
 - After it passes, a deploy action will run.
-- After that runs, the [stable docs](https://JuliaXRTS.github.io/MatterModels.jl/stable) should be updated. Check them and look for the version number.
+- After that runs, the [stable docs](https://JuliaXRTS.github.io/ElectronicStructureModels.jl/stable) should be updated. Check them and look for the version number.

--- a/docs/src/95-reference.md
+++ b/docs/src/95-reference.md
@@ -13,5 +13,5 @@ Pages = ["95-reference.md"]
 ```
 
 ```@autodocs
-Modules = [MatterModels]
+Modules = [ElectronicStructureModels]
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,10 +1,10 @@
 ```@meta
-CurrentModule = MatterModels
+CurrentModule = ElectronicStructureModels
 ```
 
-# MatterModels
+# ElectronicStructureModels
 
-Documentation for [MatterModels](https://github.com/JuliaXRTS/MatterModels.jl).
+Documentation for [ElectronicStructureModels](https://github.com/JuliaXRTS/ElectronicStructureModels.jl).
 
 ## Contributors
 

--- a/src/ElectronicStructureModels.jl
+++ b/src/ElectronicStructureModels.jl
@@ -1,4 +1,4 @@
-module MatterModels
+module ElectronicStructureModels
 
 hello_world() = "Hello, World!"
 

--- a/test/electron_system/ideal.jl
+++ b/test/electron_system/ideal.jl
@@ -3,7 +3,7 @@ using Random
 using QuadGK
 using Unitful
 
-using MatterModels
+using ElectronicStructureModels
 
 include("checks.jl")
 
@@ -31,10 +31,10 @@ APPROXS = (NoApprox(), NonDegenerated(), Degenerated())
 
 
 @testset "ne = $ne_ccm" for ne_ccm in NES_ccm
-    ne_internal = MatterModels._internalize_density(ne_ccm)
+    ne_internal = ElectronicStructureModels._internalize_density(ne_ccm)
 
-    KF = MatterModels._fermi_wave_vector(ne_internal)
-    EF = MatterModels._fermi_energy_from_kF(KF)
+    KF = ElectronicStructureModels._fermi_wave_vector(ne_internal)
+    EF = ElectronicStructureModels._fermi_energy_from_kF(KF)
     N0 = KF / (2 * pi^2)
 
     OMS = EF .* (0.0, rand(RNG), 1 + rand(RNG), 2 + rand(RNG), 3 + rand(RNG))
@@ -70,7 +70,7 @@ APPROXS = (NoApprox(), NonDegenerated(), Degenerated())
 
                 @testset "rf sanity check" begin
                     groundtruth_imag_rf =
-                        N0 * MatterModels._imag_lindhard_zero_temperature(NoApprox(), om / EF, q / KF)
+                        N0 * ElectronicStructureModels._imag_lindhard_zero_temperature(NoApprox(), om / EF, q / KF)
                     @test isapprox(
                         groundtruth_imag_rf,
                         imag_dynamic_response(test_system, (om, q)),
@@ -78,7 +78,7 @@ APPROXS = (NoApprox(), NonDegenerated(), Degenerated())
                     )
 
                     groundtruth_real_rf =
-                        N0 * MatterModels._real_lindhard_zero_temperature(NoApprox(), om / EF, q / KF)
+                        N0 * ElectronicStructureModels._real_lindhard_zero_temperature(NoApprox(), om / EF, q / KF)
                     @test isapprox(
                         groundtruth_real_rf,
                         real_dynamic_response(test_system, (om, q)),
@@ -113,7 +113,7 @@ APPROXS = (NoApprox(), NonDegenerated(), Degenerated())
     ### Finite temperature
 
     @testset "T = $T_eV" for T_eV in TEMPS_eV
-        T_internal = MatterModels._internalize_temperature.(T_eV)
+        T_internal = ElectronicStructureModels._internalize_temperature.(T_eV)
         @testset "approx = $approx" for approx in APPROXS
 
             test_system = IdealElectronSystem(ne_ccm, T_eV, approx)
@@ -142,7 +142,7 @@ APPROXS = (NoApprox(), NonDegenerated(), Degenerated())
                     end
 
                     @testset "rf sanity check" begin
-                        groundtruth_imag_rf = N0 * MatterModels._imag_lindhard_nonzero_temperature(
+                        groundtruth_imag_rf = N0 * ElectronicStructureModels._imag_lindhard_nonzero_temperature(
                             approx,
                             om / EF,
                             q / KF,
@@ -154,7 +154,7 @@ APPROXS = (NoApprox(), NonDegenerated(), Degenerated())
                             rtol = RTOL,
                         )
 
-                        groundtruth_real_rf = N0 * MatterModels._real_lindhard_nonzero_temperature(
+                        groundtruth_real_rf = N0 * ElectronicStructureModels._real_lindhard_nonzero_temperature(
                             approx,
                             om / EF,
                             q / KF,

--- a/test/electron_system/interacting.jl
+++ b/test/electron_system/interacting.jl
@@ -3,7 +3,7 @@ using Random
 using QuadGK
 using Unitful
 
-using MatterModels
+using ElectronicStructureModels
 
 include("checks.jl")
 
@@ -32,10 +32,10 @@ SCREENINGS = (NoScreening(), Screening())
 
 
 @testset "ne = $ne_ccm" for ne_ccm in NES_ccm
-    ne_internal = MatterModels._internalize_density(ne_ccm)
+    ne_internal = ElectronicStructureModels._internalize_density(ne_ccm)
 
-    KF = MatterModels._fermi_wave_vector(ne_internal)
-    EF = MatterModels._fermi_energy_from_kF(KF)
+    KF = ElectronicStructureModels._fermi_wave_vector(ne_internal)
+    EF = ElectronicStructureModels._fermi_energy_from_kF(KF)
     N0 = KF / (2 * pi^2)
 
     OMS = EF .* (0.0, rand(RNG), 1 + rand(RNG), 2 + rand(RNG), 3 + rand(RNG))
@@ -130,7 +130,7 @@ SCREENINGS = (NoScreening(), Screening())
         ### Finite temperature
 
         @testset "T = $T_eV" for T_eV in TEMPS_eV
-            T_internal = MatterModels._internalize_temperature.(T_eV)
+            T_internal = ElectronicStructureModels._internalize_temperature.(T_eV)
             @testset "approx = $approx" for approx in APPROXS
 
                 test_proper_system = IdealElectronSystem(ne_ccm, T_eV, approx)

--- a/test/electron_system/screening.jl
+++ b/test/electron_system/screening.jl
@@ -3,7 +3,7 @@ using Random
 using QuadGK
 using Unitful
 
-using MatterModels
+using ElectronicStructureModels
 
 include("checks.jl")
 
@@ -31,10 +31,10 @@ APPROXS = [NoApprox(), NonDegenerated(), Degenerated()]
 
 
 @testset "ne = $ne_ccm" for ne_ccm in NES_ccm
-    ne_internal = MatterModels._internalize_density(ne_ccm)
+    ne_internal = ElectronicStructureModels._internalize_density(ne_ccm)
 
-    KF = MatterModels._fermi_wave_vector(ne_internal)
-    EF = MatterModels._fermi_energy_from_kF(KF)
+    KF = ElectronicStructureModels._fermi_wave_vector(ne_internal)
+    EF = ElectronicStructureModels._fermi_energy_from_kF(KF)
     N0 = KF / (2 * pi^2)
 
     OMS = EF .* (0.0, rand(RNG), 1 + rand(RNG), 2 + rand(RNG), 3 + rand(RNG))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using MatterModels
+using ElectronicStructureModels
 using Test
 
 #=

--- a/test/test-basic-test.jl
+++ b/test/test-basic-test.jl
@@ -1,3 +1,3 @@
-@testset "MatterModels.jl" begin
-    @test MatterModels.hello_world() == "Hello, World!"
+@testset "ElectronicStructureModels.jl" begin
+    @test ElectronicStructureModels.hello_world() == "Hello, World!"
 end

--- a/test/test-lookup.jl
+++ b/test/test-lookup.jl
@@ -1,4 +1,4 @@
-using MatterModels
+using ElectronicStructureModels
 using Random
 
 RNG = Xoshiro(137)
@@ -8,17 +8,17 @@ a_arr = collect(range(-rand(RNG), rand(RNG); length = 4)) # cols
 b_arr = collect(range(-rand(RNG), rand(RNG); length = 5)) # rows
 vals = gaussian.(a_arr', b_arr)
 lookup_methods = [
-    MatterModels.InterpolExtrapol(),
-    MatterModels.InterpolEndValue(),
-    MatterModels.NearestInput(),
-    MatterModels.BelowInput(),
-    MatterModels.AboveInput(),
+    ElectronicStructureModels.InterpolExtrapol(),
+    ElectronicStructureModels.InterpolEndValue(),
+    ElectronicStructureModels.NearestInput(),
+    ElectronicStructureModels.BelowInput(),
+    ElectronicStructureModels.AboveInput(),
 ]
-GLT = MatterModels.GridLookupTable(a_arr, b_arr, vals)
+GLT = ElectronicStructureModels.GridLookupTable(a_arr, b_arr, vals)
 @testset "$method" for method in lookup_methods
     for a in a_arr
         for b in b_arr
-            test_val = MatterModels.lookup(method, a, b, GLT)
+            test_val = ElectronicStructureModels.lookup(method, a, b, GLT)
             groundtruth = gaussian(a, b)
             @test isapprox(groundtruth, test_val)
         end


### PR DESCRIPTION
The current name `MatterModels.jl` for the package is too generic. Therefore, we decided to rename it to `ElectronicStructureModels.jl`. 


## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->
- [x] I am following the [contributing guidelines](https://github.com/JuliaXRTS/MatterModels.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
