### PR TITLE
added missing factor of 4 pi

### DIFF
--- a/src/electron_system/interacting/screening/impl.jl
+++ b/src/electron_system/interacting/screening/impl.jl
@@ -21,7 +21,7 @@ struct CoulombPseudoPotential <: AbstractPseudoPotential end
 # TODO: insert 4pi!
 function _compute(::CoulombPseudoPotential, om_q::NTuple{2, T}) where {T <: Real}
     om, q = om_q
-    return ELEMENTARY_CHARGE_SQUARED / q^2
+    return 4 * pi * ELEMENTARY_CHARGE_SQUARED / q^2
 end
 
 ### screening

--- a/test/electron_system/screening.jl
+++ b/test/electron_system/screening.jl
@@ -80,7 +80,7 @@ APPROXS = [NoApprox(), NonDegenerated(), Degenerated()]
                     pseudo_potential(scr, (om, q)),
                 )
 
-                @test isapprox(pseudo_potential(scr, (om, q)), ELEMENTARY_CHARGE_SQUARED / q^2)
+                @test isapprox(pseudo_potential(scr, (om, q)), 4 * pi * ELEMENTARY_CHARGE_SQUARED / q^2)
 
                 @test isapprox(local_field_correction(scr, (om, q)), zero(om))
             end


### PR DESCRIPTION
There was a factor $4 \pi$ missing in the definition of the pseudo potential. This PR fixes this. 



## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/JuliaXRTS/ElectronicStructureModels.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
