### PR TITLE
revoke 4pi in pseudopotential

### DIFF
--- a/src/electron_system/interacting/screening/impl.jl
+++ b/src/electron_system/interacting/screening/impl.jl
@@ -18,10 +18,12 @@ Represents the bare Coulomb pseudo potential: V(q) = e² / q².
 """
 struct CoulombPseudoPotential <: AbstractPseudoPotential end
 
-# TODO: insert 4pi!
+# NOTE: in the literature, usually here there is a 4pi, which comes from the vacuum
+# permittivity eps_0 = 1/4pi in atomic units. In natural units used here, eps_0=1.
+# This also aligns with the definition of the DSF (see, e.g., PHYSICAL REVIEW E 78, 026411 2008)
 function _compute(::CoulombPseudoPotential, om_q::NTuple{2, T}) where {T <: Real}
     om, q = om_q
-    return 4 * pi * ELEMENTARY_CHARGE_SQUARED / q^2
+    return ELEMENTARY_CHARGE_SQUARED / q^2
 end
 
 ### screening

--- a/test/electron_system/screening.jl
+++ b/test/electron_system/screening.jl
@@ -80,7 +80,7 @@ APPROXS = [NoApprox(), NonDegenerated(), Degenerated()]
                     pseudo_potential(scr, (om, q)),
                 )
 
-                @test isapprox(pseudo_potential(scr, (om, q)), 4 * pi * ELEMENTARY_CHARGE_SQUARED / q^2)
+                @test isapprox(pseudo_potential(scr, (om, q)), ELEMENTARY_CHARGE_SQUARED / q^2)
 
                 @test isapprox(local_field_correction(scr, (om, q)), zero(om))
             end


### PR DESCRIPTION
This revokes #24 

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [ ] I am following the [contributing guidelines](https://github.com/JuliaXRTS/ElectronicStructureModels.jl/blob/main/docs/src/90-contributing.md)
- [ ] Tests are passing
- [ ] Lint workflow is passing
- [ ] Docs were updated and workflow is passing
